### PR TITLE
bump stackage to nightly - 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,9 @@ env:
   global:
     - ANALYZE_V=0.2.0
     - DENSE_LINEAR_ALGEBRA_V=0.1.0.0
-    - DATASETS_V=0.3.0
+    - DATASETS_V=0.4.0
   matrix:
-    - ARGS="--resolver lts-11.22"  
-    - ARGS="--resolver lts-12.13"
-    - ARGS="--resolver lts-13.0"
-
+    - ARGS="--resolver nightly-2019-02-27"
 
 before_install:
 # Download and unpack the stack executable

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ More detailed developer information can be found in the wiki : https://github.co
 ### GHC and Stackage compatibility
 
 
-Tested with :
+Tested against :
 
-- Stackage LTS-11.22 (GHC 8.2.2)
-- Stackage LTS-12.13 (GHC 8.4.3)
-- Stackage LTS-13.0  (GHC 8.6.3)
+- Stackage nightly-2019-02-27 (GHC 8.6.3)
 
 
 ## Contributing

--- a/datasets/datasets.cabal
+++ b/datasets/datasets.cabal
@@ -39,7 +39,7 @@ Cabal-Version: 	     >= 1.10
 homepage:            https://github.com/DataHaskell/dh-core
 bug-reports:         https://github.com/DataHaskell/dh-core/issues
 category:            Statistics, Machine Learning, Data Mining, Data
-Tested-With:         GHC == 7.10.2, GHC == 7.10.3, GHC == 8.0.1, GHC == 8.4.3
+Tested-With:         GHC == 7.10.2, GHC == 7.10.3, GHC == 8.0.1, GHC == 8.4.3, GHC == 8.6.3
 extra-source-files:
                    changelog.md
                    datafiles/iris.data
@@ -105,7 +105,7 @@ Library
                , filepath
                , hashable
                , JuicyPixels
-               , microlens
+               -- , microlens
                , mtl
                , mwc-random
                , parallel
@@ -115,7 +115,7 @@ Library
                , streaming-attoparsec
                , streaming-bytestring
                , streaming-cassava >= 0.1.0.1
-               , streaming-commons
+               -- , streaming-commons
                , stringsearch
                , tar
                , text
@@ -124,7 +124,6 @@ Library
                , vector
                , safe-exceptions
                , zlib
-                 -- , wreq
 
 
 Benchmark bench
@@ -144,7 +143,6 @@ Benchmark bench
      , filepath
      , JuicyPixels
      , mwc-random
-     , req
      , safe-exceptions
      , streaming
 

--- a/datasets/src/Numeric/Dataloader.hs
+++ b/datasets/src/Numeric/Dataloader.hs
@@ -13,6 +13,7 @@
 -- primarily to provide a unified API with training that is not batch-oriented.
 -------------------------------------------------------------------------------
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds -Wno-name-shadowing #-}
 module Numeric.Dataloader
   ( Dataloader(..)
   , uniformIxline

--- a/datasets/src/Numeric/Datasets/Internal/Streaming.hs
+++ b/datasets/src/Numeric/Datasets/Internal/Streaming.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds -Wno-name-shadowing #-}
 module Numeric.Datasets.Internal.Streaming
     ( streamDataset
     , streamByteString

--- a/dh-core/stack.yaml
+++ b/dh-core/stack.yaml
@@ -1,6 +1,7 @@
 # resolver: lts-12.13 # GHC 8.4.3
 # resolver: lts-11.22 # GHC 8.2.2
-resolver: lts-13.0 # GHC 8.6.3
+# resolver: lts-13.0 # GHC 8.6.3
+resolver: nightly-2019-02-27
 
 packages:
 - .
@@ -11,9 +12,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-extra-deps:
-- "streaming-attoparsec-1.0.0@sha256:5db3acf7fd2d4c80bda12a8d80cb981bb499c2f586f08a27c31ae6602dd2181e"
-- "streaming-cassava-0.1.0.1@sha256:2d1dfeb09af62009e88311fe92f44d06dafb5cdd38879b437ea6adb3bc40acfe"
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/dh-core/test/LibSpec.hs
+++ b/dh-core/test/LibSpec.hs
@@ -1,9 +1,9 @@
 module LibSpec where
 
 import Test.Hspec
-import Test.Hspec.QuickCheck
+-- import Test.Hspec.QuickCheck
 
-import Lib 
+-- import Lib 
 
 main :: IO ()
 main = hspec spec


### PR DESCRIPTION
* build `datasets` against Stackage `nightly-2019-02-27` (https://www.stackage.org/nightly-2019-02-27)
* travis builds `dh-core` (and all subprojects) against " 

fixes #43 