### PR TITLE
Implement `column` from `unsafeIndex`

### DIFF
--- a/dense-linear-algebra/src/Statistics/Matrix.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix.hs
@@ -223,7 +223,7 @@ norm = sqrt . sumVector kbn . U.map square
 
 -- | Return the given column.
 column :: Matrix -> Int -> Vector
-column (Matrix r c v) i = U.backpermute v $ U.enumFromStepN i c r
+column (Matrix r c v) j= U.generate r (\x -> v `U.unsafeIndex` (j + x * c))
 {-# INLINE column #-}
 
 -- | Return the given row.

--- a/dense-linear-algebra/src/Statistics/Matrix.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix.hs
@@ -223,7 +223,7 @@ norm = sqrt . sumVector kbn . U.map square
 
 -- | Return the given column.
 column :: Matrix -> Int -> Vector
-column (Matrix r c v) j= U.generate r (\x -> v `U.unsafeIndex` (j + x * c))
+column (Matrix r c v) j= U.generate r (\i -> v `U.unsafeIndex` (j + i * c))
 {-# INLINE column #-}
 
 -- | Return the given row.


### PR DESCRIPTION
This gets rid of the temporary vector that `U.enumFromStepN`was allocating. This vector was seemingly preventing stream fusion to occur in `multiply`. According to the benchmarks from #56, on 100*100 matrices, the new `column` is twice as fast, allocates half as much memory, and `multiply` goes from allocating 17,040,080 bytes to 80,080 (when multiply is *not* inlined, ~240 000 when it is) and is a bit less than two times faster. With the llvm backend, it's well within the range of a naive C implementation.