### PR TITLE
Add `Fast` modules to DLA

### DIFF
--- a/dense-linear-algebra/bench/ChronosBench.hs
+++ b/dense-linear-algebra/bench/ChronosBench.hs
@@ -34,6 +34,7 @@ runtimelight v a = do
     
     C.defaultMainWith (C.defaultConfig {C.timeout = Just 3}) [
                    C.bench "norm" M.norm v2,
+                   C.bench "Fast.norm" F.norm v2,
 
                    C.bench "multiplyV" (M.multiplyV a) (v2),
             

--- a/dense-linear-algebra/bench/ChronosBench.hs
+++ b/dense-linear-algebra/bench/ChronosBench.hs
@@ -37,6 +37,7 @@ runtimelight v a = do
                    C.bench "Fast.norm" F.norm v2,
 
                    C.bench "multiplyV" (M.multiplyV a) (v2),
+                   C.bench "Fast.multiplyV" (F.multiplyV a) (v2),
             
                    C.bench "transpose" M.transpose a ,
                    C.bench "ident" M.ident n,

--- a/dense-linear-algebra/bench/ChronosBench.hs
+++ b/dense-linear-algebra/bench/ChronosBench.hs
@@ -1,6 +1,8 @@
 module Main where
 
 import qualified Statistics.Matrix as M
+import qualified Statistics.Matrix.Fast as F
+import qualified Statistics.Matrix.Fast.Algorithms as FA
 import           Statistics.Matrix (Matrix (..))
 import qualified Statistics.Matrix.Algorithms as A
 
@@ -31,7 +33,7 @@ runtimelight v a = do
       v2 = U.take n v
     
     C.defaultMainWith (C.defaultConfig {C.timeout = Just 3}) [
-                   C.bench "norm" M.norm v,
+                   C.bench "norm" M.norm v2,
 
                    C.bench "multiplyV" (M.multiplyV a) (v2),
             
@@ -45,7 +47,9 @@ runtimeheavy a b = do
     
     C.defaultMainWith (C.defaultConfig {C.timeout = Just 1}) [
                    C.bench "multiply" (M.multiply a) b,
-                   C.bench "qr" A.qr a
+                   C.bench "Fast.multiply" (F.multiply a) b,
+                   C.bench "qr" A.qr a,
+                   C.bench "Fast.qr" FA.qr a
                    ]
 
 

--- a/dense-linear-algebra/bench/WeighBench.hs
+++ b/dense-linear-algebra/bench/WeighBench.hs
@@ -34,6 +34,7 @@ weight v a b = do
       v2 = U.take n v
     W.mainWith (do 
         W.func "norm" M.norm v2
+        W.func "Fast.norm" F.norm v2
 
         W.func "multiplyV" (M.multiplyV a) (v2)
 

--- a/dense-linear-algebra/bench/WeighBench.hs
+++ b/dense-linear-algebra/bench/WeighBench.hs
@@ -37,7 +37,7 @@ weight v a b = do
         W.func "Fast.norm" F.norm v2
 
         W.func "multiplyV" (M.multiplyV a) (v2)
-
+        W.func "Fast.multiplyV" (F.multiplyV a) (v2)
         W.func "transpose" M.transpose a
         W.func "ident" M.ident n
         W.func "diag" M.diag v2

--- a/dense-linear-algebra/bench/WeighBench.hs
+++ b/dense-linear-algebra/bench/WeighBench.hs
@@ -1,6 +1,8 @@
 module Main where
 
 import qualified Statistics.Matrix as M
+import qualified Statistics.Matrix.Fast as F
+import qualified Statistics.Matrix.Fast.Algorithms as FA
 import           Statistics.Matrix (Matrix (..))
 import qualified Statistics.Matrix.Algorithms as A
 
@@ -33,13 +35,19 @@ weight v a b = do
     W.mainWith (do 
         W.func "norm" M.norm v2
 
-        W.func "multiply" (M.multiply a) b
         W.func "multiplyV" (M.multiplyV a) (v2)
-        W.func "qr" A.qr a
 
         W.func "transpose" M.transpose a
         W.func "ident" M.ident n
-        W.func "diag" M.diag v2)
+        W.func "diag" M.diag v2
+
+        W.func "multiply" (M.multiply a) b
+        W.func "Fast.multiply" (F.multiply a) b
+        
+        W.func "qr" A.qr a
+        W.func "Fast.qr" FA.qr a
+
+        )
 
 
 

--- a/dense-linear-algebra/dense-linear-algebra.cabal
+++ b/dense-linear-algebra/dense-linear-algebra.cabal
@@ -26,6 +26,8 @@ library
                        Statistics.Matrix.Function
                        Statistics.Matrix.Mutable
                        Statistics.Matrix.Types
+                       Statistics.Matrix.Fast
+                       Statistics.Matrix.Fast.Algorithms
   build-depends:       base                    >= 4.5 && < 5
                      , deepseq                 >= 1.1.0.2
                      , math-functions          >= 0.1.7

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -2,16 +2,16 @@
 
 module Statistics.Matrix.Fast (
     multiply,
-    norm
+    norm,
+    multiplyV
     ) where
 
 import Prelude hiding (exponent, map)
-import Control.Applicative ((<$>))
 import Control.Monad.ST
 import qualified Data.Vector.Unboxed as U
-import           Data.Vector.Unboxed   ((!))
-import qualified Data.Vector.Unboxed.Mutable as UM
 
+
+import Statistics.Matrix (row)
 import Statistics.Matrix.Function
 import Statistics.Matrix.Types
 import Statistics.Matrix.Mutable  (unsafeNew,unsafeWrite,unsafeFreeze)
@@ -35,5 +35,13 @@ accum ithrow (Matrix r1 c1 v1) jthcol (Matrix _ c2 v2) = sub 0 0
                                     valRow = U.unsafeIndex v1 (ithrow*c1 + ij)
                                     valCol = U.unsafeIndex v2 (ij*c2+jthcol)
 
+multiplyV :: Matrix -> Vector -> Vector
+multiplyV m v
+  | cols m == c = U.generate (rows m) (U.sum . U.zipWith (*) v . row m)
+  | otherwise   = error $ "matrix/vector unconformable " ++ show (cols m,c)
+  where c = U.length v
+
+
 norm :: Vector -> Double
 norm = sqrt . U.sum . U.map square
+

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 
 module Statistics.Matrix.Fast (
-    multiply
+    multiply,
+    norm
     ) where
 
 import Prelude hiding (exponent, map)
@@ -33,3 +34,6 @@ accum ithrow (Matrix r1 c1 v1) jthcol (Matrix _ c2 v2) = sub 0 0
                                    where 
                                     valRow = U.unsafeIndex v1 (ithrow*c1 + ij)
                                     valCol = U.unsafeIndex v2 (ij*c2+jthcol)
+
+norm :: Vector -> Double
+norm = sqrt . U.sum . U.map square

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -16,7 +16,8 @@ import Statistics.Matrix.Function
 import Statistics.Matrix.Types
 import Statistics.Matrix.Mutable  (unsafeNew,unsafeWrite,unsafeFreeze)
 
-
+-- | Matrix-matrix multiplication in a more imperative fashion. Matrices must be of compatible
+-- sizes (/note: not checked/). Faster but less accurate than Statistics.Matrix.multiply
 multiply :: Matrix -> Matrix -> Matrix
 multiply m1@(Matrix r1 _ _) m2@(Matrix _ c2 _) = runST $ do
   m3 <- unsafeNew r1 c2
@@ -35,13 +36,15 @@ accum ithrow (Matrix r1 c1 v1) jthcol (Matrix _ c2 v2) = sub 0 0
                                     valRow = U.unsafeIndex v1 (ithrow*c1 + ij)
                                     valCol = U.unsafeIndex v2 (ij*c2+jthcol)
 
+-- | Matrix-vector multiplication, with better performances but not as accurate as
+-- Statistics.Matrix.multiplyV
 multiplyV :: Matrix -> Vector -> Vector
 multiplyV m v
   | cols m == c = U.generate (rows m) (U.sum . U.zipWith (*) v . row m)
   | otherwise   = error $ "matrix/vector unconformable " ++ show (cols m,c)
   where c = U.length v
 
-
+-- | Norm of a vector. Faster but less accurate than Statistics.Matrix.norm
 norm :: Vector -> Double
 norm = sqrt . U.sum . U.map square
 

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Statistics.Matrix.Fast (
+    multiply
+    ) where
+
+import Prelude hiding (exponent, map)
+import Control.Applicative ((<$>))
+import Control.Monad.ST
+import qualified Data.Vector.Unboxed as U
+import           Data.Vector.Unboxed   ((!))
+import qualified Data.Vector.Unboxed.Mutable as UM
+
+import Statistics.Matrix.Function
+import Statistics.Matrix.Types
+import Statistics.Matrix.Mutable  (unsafeNew,unsafeWrite,unsafeFreeze)
+
+
+multiply :: Matrix -> Matrix -> Matrix
+multiply m1@(Matrix r1 _ _) m2@(Matrix _ c2 _) = runST $ do
+  m3 <- unsafeNew r1 c2
+  for 0 c2 $ \j -> do
+    for 0 r1 $ \i -> do
+      let 
+        z = accum i m1 j m2 
+      unsafeWrite m3 i j z
+  unsafeFreeze m3
+
+accum :: Int -> Matrix -> Int -> Matrix -> Double
+accum ithrow (Matrix r1 c1 v1) jthcol (Matrix _ c2 v2) = sub 0 0
+  where sub !acc !ij | ij == r1 = acc
+                     | otherwise = sub ( valRow*valCol + acc ) (ij+1)
+                                   where 
+                                    valRow = U.unsafeIndex v1 (ithrow*c1 + ij)
+                                    valCol = U.unsafeIndex v2 (ij*c2+jthcol)

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast/Algorithms.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast/Algorithms.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 
 -- |
--- Module    : Statistics.Matrix.Algorithms
--- Copyright : 2014 Bryan O'Sullivan
+-- Module    : Statistics.Matrix.Fast.Algorithms
+-- Copyright : 2019 Magalame
 -- License   : BSD3
 --
 -- Useful matrix functions.

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast/Algorithms.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast/Algorithms.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- |
+-- Module    : Statistics.Matrix.Algorithms
+-- Copyright : 2014 Bryan O'Sullivan
+-- License   : BSD3
+--
+-- Useful matrix functions.
+
+module Statistics.Matrix.Fast.Algorithms
+    (
+      qr
+    ) where
+
+import Control.Applicative ((<$>), (<*>))
+import Control.Monad.ST (ST, runST)
+import Prelude hiding (replicate)
+import Statistics.Matrix (Matrix (..),dimension, for)
+import qualified Statistics.Matrix.Mutable as M
+import qualified Data.Vector.Unboxed as U
+
+-- | /O(r*c)/ Compute the QR decomposition of a matrix.
+-- The result returned is the matrices (/q/,/r/).
+qr :: Matrix -> (Matrix, Matrix)
+qr mat = runST $ do
+  let (m,n) = dimension mat
+
+  r <- M.replicate n n 0
+  a <- M.thaw mat
+  for 0 n $ \j -> do
+    cn <- M.immutably a $ \aa -> sqrt $ normCol j aa
+    M.unsafeWrite r j j cn
+    for 0 m $ \i -> M.unsafeModify a i j (/ cn)
+    for (j+1) n $ \jj -> do
+      p <- innerProduct a j jj
+      M.unsafeWrite r j jj p
+      for 0 m $ \i -> do
+        aij <- M.unsafeRead a i j
+        M.unsafeModify a i jj $ subtract (p * aij)
+  (,) <$> M.unsafeFreeze a <*> M.unsafeFreeze r
+
+normCol :: Int -> Matrix -> Double
+normCol jthcol (Matrix r c v) = sub 0 0
+  where sub !acc !ij | ij == r = acc
+                     | otherwise = sub ( valCol*valCol + acc ) (ij+1)
+                                   where
+                                    valCol = U.unsafeIndex v (ij*c+jthcol)
+
+innerProduct :: M.MMatrix s -> Int -> Int -> ST s Double
+innerProduct mmat j k = M.immutably mmat $ \mat ->
+  dotCol j mat k mat
+
+dotCol :: Int -> Matrix -> Int -> Matrix -> Double
+dotCol jthcol (Matrix r1 c1 v1) kthcol (Matrix _ c2 v2) = sub 0 0
+  where sub !acc !ij | ij == r1 = acc
+                     | otherwise = sub ( valColj*valColk + acc ) (ij+1)
+                                   where
+                                    valColk = U.unsafeIndex v2 (ij*c2+kthcol)
+                                    valColj = U.unsafeIndex v1 (ij*c1+jthcol)

--- a/dense-linear-algebra/stack.yaml
+++ b/dense-linear-algebra/stack.yaml
@@ -9,6 +9,7 @@ extra-deps:
 - torsor-0.1
 - chronos-1.0.5
 - chronos-bench-0.2.0.2
+- primitive-0.6.4.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
The current default modules in DLA are optimized for accuracy, with the use of the `Numeric.Sum` module. This is good for certain numeric applications, but other would benefit more from a focus on performance. 

The new modules are `Statistics.Matrix.Fast`, and `Statistics.Matrix.Fast.Algorithms`. Since doing away with the `Sum` module allows for more general modification, I used a more heavily imperative style, for w finer control over allocation. However a future PR should bring in a more functional style, with generalization added. With more details:

for example `norm . column $ m` would not fuse and would actually allocate a column
the solution adopted here was to manually fuse operations. The problem is that situations like `norm . multiply m1 . multiply m2 $ m3` would still allocate two matrices. The goal would be to allow for the fusing of the whole operation, that would be pretty amazing. I wonder what would the effect in the case of, say, matrix exponentiation.

The whole thing probably just boils down to how to use `Stream` and `New` properly enough to guarantee the stream fusion we want.