### PR TITLE
Refactoring `transpose`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ script:
 - stack $ARGS --no-terminal build dense-linear-algebra:weigh-bench
 - stack $ARGS --no-terminal build dense-linear-algebra:chronos-bench
 # - stack $ARGS --no-terminal bench datasets:bench 
-- cat .stack-work/logs/analyze-${ANALYZE_V}-test.log
-- cat .stack-work/logs/dense-linear-algebra-${DENSE_LINEAR_ALGEBRA_V}-test.log
-- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
+#- cat .stack-work/logs/analyze-${ANALYZE_V}-test.log
+#- cat .stack-work/logs/dense-linear-algebra-${DENSE_LINEAR_ALGEBRA_V}-test.log
+#- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
 
 # Caching so the next build will be fast too.
 cache:

--- a/dense-linear-algebra/bench/ChronosBench.hs
+++ b/dense-linear-algebra/bench/ChronosBench.hs
@@ -39,7 +39,8 @@ runtimelight v a = do
                    C.bench "multiplyV" (M.multiplyV a) (v2),
                    C.bench "Fast.multiplyV" (F.multiplyV a) (v2),
             
-                   C.bench "transpose" M.transpose a ,
+                   C.bench "transpose" M.transpose a,
+                   C.bench "Fast.transpose" F.transpose a ,
                    C.bench "ident" M.ident n,
                    C.bench "diag" M.diag v2
                    ]

--- a/dense-linear-algebra/bench/WeighBench.hs
+++ b/dense-linear-algebra/bench/WeighBench.hs
@@ -39,6 +39,7 @@ weight v a b = do
         W.func "multiplyV" (M.multiplyV a) (v2)
         W.func "Fast.multiplyV" (F.multiplyV a) (v2)
         W.func "transpose" M.transpose a
+        W.func "Fast.transpose" F.transpose a
         W.func "ident" M.ident n
         W.func "diag" M.diag v2
 

--- a/dense-linear-algebra/src/Statistics/Matrix.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix.hs
@@ -260,14 +260,6 @@ unsafeBounds k (Matrix _ cs v) r c = k v $! r * cs + c
 {-# INLINE unsafeBounds #-}
 
 transpose :: Matrix -> Matrix
-transpose (Matrix r0 c0 v0) 
-  = Matrix c0 r0 $ runST $ do
-    vec <- UM.unsafeNew (r0*c0)
-    for 0 r0 $ \i -> do
-      UM.unsafeWrite vec (i + i * c0) $ v0 `U.unsafeIndex` (i + i * c0)
-      for (i+1) c0 $ \j -> do
-        let tmp = v0 `U.unsafeIndex` (j + i * c0)
-            tmp2 = v0 `U.unsafeIndex` (i + j * c0)
-        UM.unsafeWrite vec (j + i * c0) tmp2
-        UM.unsafeWrite vec (i + j * c0) tmp
-    U.unsafeFreeze vec
+transpose m@(Matrix r0 c0 _) = Matrix c0 r0 . U.generate (r0*c0) $ \i ->
+  let (r,c) = i `quotRem` r0
+  in unsafeIndex m c r

--- a/dense-linear-algebra/src/Statistics/Matrix.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix.hs
@@ -260,6 +260,14 @@ unsafeBounds k (Matrix _ cs v) r c = k v $! r * cs + c
 {-# INLINE unsafeBounds #-}
 
 transpose :: Matrix -> Matrix
-transpose m@(Matrix r0 c0 _) = Matrix c0 r0 . U.generate (r0*c0) $ \i ->
-  let (r,c) = i `quotRem` r0
-  in unsafeIndex m c r
+transpose (Matrix r0 c0 v0) 
+  = Matrix c0 r0 $ runST $ do
+    vec <- UM.unsafeNew (r0*c0)
+    for 0 r0 $ \i -> do
+      UM.unsafeWrite vec (i + i * c0) $ v0 `U.unsafeIndex` (i + i * c0)
+      for (i+1) c0 $ \j -> do
+        let tmp = v0 `U.unsafeIndex` (j + i * c0)
+            tmp2 = v0 `U.unsafeIndex` (i + j * c0)
+        UM.unsafeWrite vec (j + i * c0) tmp2
+        UM.unsafeWrite vec (i + j * c0) tmp
+    U.unsafeFreeze vec

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -10,7 +10,7 @@ module Statistics.Matrix.Fast (
 import Prelude hiding (exponent, map)
 import Control.Monad.ST
 import qualified Data.Vector.Unboxed as U
-
+import qualified Data.Vector.Unboxed.Mutable as UM
 
 import Statistics.Matrix (row)
 import Statistics.Matrix.Function

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -3,7 +3,8 @@
 module Statistics.Matrix.Fast (
     multiply,
     norm,
-    multiplyV
+    multiplyV,
+    transpose
     ) where
 
 import Prelude hiding (exponent, map)
@@ -48,3 +49,15 @@ multiplyV m v
 norm :: Vector -> Double
 norm = sqrt . U.sum . U.map square
 
+transpose :: Matrix -> Matrix
+transpose (Matrix r0 c0 v0) 
+  = Matrix c0 r0 $ runST $ do
+    vec <- UM.unsafeNew (r0*c0)
+    for 0 r0 $ \i -> do
+      UM.unsafeWrite vec (i + i * c0) $ v0 `U.unsafeIndex` (i + i * c0)
+      for (i+1) c0 $ \j -> do
+        let tmp = v0 `U.unsafeIndex` (j + i * c0)
+            tmp2 = v0 `U.unsafeIndex` (i + j * c0)
+        UM.unsafeWrite vec (j + i * c0) tmp2
+        UM.unsafeWrite vec (i + j * c0) tmp
+    U.unsafeFreeze vec


### PR DESCRIPTION
According to the benches on my machine I have a ~ x6 speedup.

The reason is that `quotRem` is a very expensive operation compared to simple multiplication and addition