### PR TITLE
Fix fast matrix mutiplication implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ script:
 - stack $ARGS --no-terminal build dense-linear-algebra:weigh-bench
 - stack $ARGS --no-terminal build dense-linear-algebra:chronos-bench
 # - stack $ARGS --no-terminal bench datasets:bench 
-- cat .stack-work/logs/analyze-${ANALYZE_V}-test.log
-- cat .stack-work/logs/dense-linear-algebra-${DENSE_LINEAR_ALGEBRA_V}-test.log
-- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
+#- cat .stack-work/logs/analyze-${ANALYZE_V}-test.log
+#- cat .stack-work/logs/dense-linear-algebra-${DENSE_LINEAR_ALGEBRA_V}-test.log
+#- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
 
 # Caching so the next build will be fast too.
 cache:

--- a/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
+++ b/dense-linear-algebra/src/Statistics/Matrix/Fast.hs
@@ -29,8 +29,8 @@ multiply m1@(Matrix r1 _ _) m2@(Matrix _ c2 _) = runST $ do
   unsafeFreeze m3
 
 accum :: Int -> Matrix -> Int -> Matrix -> Double
-accum ithrow (Matrix r1 c1 v1) jthcol (Matrix _ c2 v2) = sub 0 0
-  where sub !acc !ij | ij == r1 = acc
+accum ithrow (Matrix _ c1 v1) jthcol (Matrix _ c2 v2) = sub 0 0
+  where sub !acc !ij | ij == c1 = acc
                      | otherwise = sub ( valRow*valCol + acc ) (ij+1)
                                    where 
                                     valRow = U.unsafeIndex v1 (ithrow*c1 + ij)


### PR DESCRIPTION
I finally figured out why I was getting much slower benchmarks in massiv comparing to the implementation in `dense-linear-algebra`. I was benchmarking multiplication of A(200x600) x B(600x200) matrices.

To reproduce the bug I used the benchmarks from [fastest-matrices](https://github.com/lehins/fastest-matrices/blob/master/bench/Runtime.hs):
```haskell
λ> uDLA <- vectorGen
λ> uList = U.toList uDLA
λ> vMA = MA.fromList MA.Seq uList :: MA.Array MA.P MA.Ix1 Double
λ> aMA <- MA.resizeM (MA.Sz2 4 9) vMA :: IO (MA.Array MA.P MA.Ix2 Double)
λ> bMA <- MA.resizeM (MA.Sz2 9 4) vMA :: IO (MA.Array MA.P MA.Ix2 Double)
λ> aMA MA.|*| bMA
Array P Seq (Sz (4 :. 4))
  [ [ 1.7700914751064436, 1.2309820977803536, 1.707826152795249, 1.6772335798257119 ]
  , [ 2.555702366316134, 1.3237126494921863, 2.849472501297746, 2.560149705981688 ]
  , [ 1.6580016676221996, 1.8209635429144693, 2.6035157013237877, 2.2959408241699633 ]
  , [ 2.094817978804908, 1.56376512947369, 2.4469042480887095, 2.3480437251846893 ]
  ]
λ> aNH = NP.fromList uList :: NH.Array V.Vector '[4, 9] Double
λ> bNH = NP.fromList uList :: NH.Array V.Vector '[9, 4] Double
λ> NH.mmult aNH bNH
[[1.7700914751064438, 1.2309820977803536, 1.7078261527952487, 1.6772335798257119],
 [2.5557023663161345, 1.3237126494921863, 2.849472501297746, 2.5601497059816873],
 [1.6580016676221996, 1.8209635429144693, 2.603515701323788, 2.2959408241699633],
 [2.0948179788049086, 1.56376512947369, 2.446904248088709, 2.3480437251846893]]
λ> aDLA = M.Matrix 4 9 uDLA
λ> bDLA = M.Matrix 9 4 uDLA
λ> MF.multiply aDLA bDLA
(4,4) 0.789  0.4997 0.6749 0.8261
      1.1999 0.6489 1.3264 1.3812
      0.8818 0.9981 1.4134 1.4628
      0.5801 0.6332 0.5415 0.7313
```