### PR TITLE
Generate code coverage report and upload to codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 # around some quirks in Travis's terminal implementation.
 script:
 - cd dh-core
-- stack $ARGS --no-terminal --install-ghc test --haddock
+- stack $ARGS --no-terminal --install-ghc test --haddock --coverage
 - stack $ARGS --no-terminal bench analyze:bench
 - stack $ARGS --no-terminal build dense-linear-algebra:weigh-bench
 - stack $ARGS --no-terminal build dense-linear-algebra:chronos-bench
@@ -45,6 +45,9 @@ script:
 #- cat .stack-work/logs/analyze-${ANALYZE_V}-test.log
 #- cat .stack-work/logs/dense-linear-algebra-${DENSE_LINEAR_ALGEBRA_V}-test.log
 #- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
+
+after_success:
+- bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,9 @@ script:
 #- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
 
 after_script:
-- stack install codecov-haskell
-- codecov-haskell
+- stack hpc report --all
+- stack install stack-hpc-coveralls
+- shc --repo-token=$COVERALLS_REPO_TOKEN spec
 
 after_success:
 - bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
 after_script:
 - stack hpc report --all
 - travis_retry curl -sSL https://github.com/lehins/stack-hpc-coveralls/releases/download/0.0.5.0/shc.tar.gz | tar xz shc 
-- ./shc --repo-token=$COVERALLS_REPO_TOKEN combined custom
+- ./shc --repo-token=$COVERALLS_REPO_TOKEN combined all
 # - stack exec shc --repo-token=$COVERALLS_REPO_TOKEN spec
 
 # Caching so the next build will be fast too.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,7 @@ script:
 
 after_script:
 - stack hpc report --all
-- stack install stack-hpc-coveralls
 - shc --repo-token=$COVERALLS_REPO_TOKEN spec
-
-after_success:
-- bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
 
 # Caching so the next build will be fast too.
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,10 @@ script:
 #- cat .stack-work/logs/dense-linear-algebra-${DENSE_LINEAR_ALGEBRA_V}-test.log
 #- cat .stack-work/logs/datasets-${DATASETS_V}-test.log
 
+after_script:
+- stack install codecov-haskell
+- codecov-haskell
+
 after_success:
 - bash <(curl -s https://codecov.io/bash) || echo 'Codecov failed to upload'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ script:
 
 after_script:
 - stack hpc report --all
-- shc --repo-token=$COVERALLS_REPO_TOKEN spec
+- travis_retry curl -sSL https://github.com/lehins/stack-hpc-coveralls/releases/download/0.0.5.0/shc.tar.gz | tar xz shc 
+- ./shc --repo-token=$COVERALLS_REPO_TOKEN combined custom
+# - stack exec shc --repo-token=$COVERALLS_REPO_TOKEN spec
 
 # Caching so the next build will be fast too.
 cache:

--- a/dh-core/stack.yaml
+++ b/dh-core/stack.yaml
@@ -16,6 +16,8 @@ packages:
 extra-deps:
 - statistics-0.14.0.2
 - chronos-bench-0.2.0.2
+- github: mjarosie/stack-hpc-coveralls
+  commit: 318262fe4c8b5ee2de30be54a9d6d36f1babefbf 
 
 nix:
   enable: false


### PR DESCRIPTION
Resolves #46 

I couldn't successfully install `codecov-haskell` locally and the repository wasn't updated since June 2017 so I've used codecov.io bash uploader instead of the haskell-specific tool as per [the documentation](https://docs.codecov.io/v4.3.0/docs/about-the-codecov-bash-uploader):

> It has been a tradition for other products that integrate with different languages to create a specific plugin for each language. We believe this is a bad practice that quickly leads to out-of-date and poorly maintained packages.
> One uploader to rule them all.

I think the .cabal file still needs to be changed a bit as hpc produces empty coverage reports for all libraries apart from `dense-linear-algebra`, hence the PR is still WIP, will update after I fix it : )