### PR TITLE
Fix BostonHousing data set URL

### DIFF
--- a/datasets/src/Numeric/Datasets/BostonHousing.hs
+++ b/datasets/src/Numeric/Datasets/BostonHousing.hs
@@ -61,4 +61,4 @@ instance FromRecord BostonHousing where
 
 bostonHousing :: Dataset BostonHousing
 bostonHousing = withPreprocess fixedWidthToCSV $
-            csvDataset $ URL $ umassMLDB /: "housing" /: "housing.data"
+            csvDataset $ URL $ uciMLDB /: "housing" /: "housing.data"


### PR DESCRIPTION
## Description

Update BostonHousing URL to use `uciMLDB`. 
Fixes  #68